### PR TITLE
Remove astropy as test dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
         - PYTEST_VERSION=3.2
         - PYTEST_COMMAND='pytest'
         - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='six'
 
     matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
-0.2
+0.2 (unreleased)
 ================
+
+- Remove test dependency on astropy. [#4]
 
 
 0.1 (2017-10-09)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,7 @@ include CHANGES.rst
 
 include setup.cfg
 
+include tests/*.py
+include tests/data/*.txt
+
 global-exclude *.pyc *.o

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ environment:
       PYTEST_VERSION: "3.2"
       PYTEST_COMMAND: "pytest"
       NUMPY_VERSION: "stable"
-      ASTROPY_VERSION: "stable"
       CONDA_DEPENDENCIES: "six"
       PYTHON_ARCH: "64"
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
     ],
     keywords=[ 'detect', 'open', 'file', 'handle', 'psutil', 'pytest', 'py.test' ],
     install_requires=[ 'pytest>=2.8.0', 'psutil' ],
-    tests_require=[ 'astropy' ],
     python_requires='>=2.7',
     entry_points={
         'pytest11': [

--- a/tests/test_open_file_detection.py
+++ b/tests/test_open_file_detection.py
@@ -1,12 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.utils.data import get_pkg_data_filename
+import os
+
+PKG_DATA_DIR = os.path.dirname(__file__)
 
 fd = None
 
 
 def test_open_file_detection():
     global fd
-    fd = open(get_pkg_data_filename('data/open_file_detection.txt'))
+    fd = open(os.path.join(PKG_DATA_DIR, 'data/open_file_detection.txt'))
 
 
 def teardown():


### PR DESCRIPTION
This fixes #2.

It also fixes #3 by adding the test Python source and data files to `MANIFEST.in`.