### PR TITLE
Use LooseVersion to check for pytest 3.6+

### DIFF
--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -31,6 +31,7 @@ def pytest_addoption(parser):
                   "may be specified by their base name (ignoring their full "
                   "path) or by absolute path", type="args", default=())
 
+
 def pytest_configure(config):
 
     config.getini('markers').append(
@@ -61,6 +62,7 @@ def _get_open_file_list():
 
     return set(files)
 
+
 def pytest_runtest_setup(item):
 
     # Store a list of the currently opened files so we can compare
@@ -72,7 +74,7 @@ def pytest_runtest_setup(item):
             ignore = item.get_closest_marker('openfiles_ignore')
         else:
             ignore = item.get_marker('openfiles_ignore')
-        if ignore:
+        if not ignore:
             item.open_files = _get_open_file_list()
 
 

--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -7,7 +7,7 @@ import imp
 import os
 import fnmatch
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 import pytest
 
@@ -15,6 +15,8 @@ try:
     import importlib.machinery as importlib_machinery
 except ImportError:
     importlib_machinery = None
+
+_pytest_36 = LooseVersion(pytest.__version__) >= LooseVersion("3.6")
 
 
 def pytest_addoption(parser):
@@ -59,19 +61,19 @@ def _get_open_file_list():
 
     return set(files)
 
-
 def pytest_runtest_setup(item):
-
-    # Retain backwards compatibility with earlier versions of pytest
-    if StrictVersion(pytest.__version__) < StrictVersion("3.6"):
-        ignore = item.get_marker('openfiles_ignore')
-    else:
-        ignore = item.get_closest_marker('openfiles_ignore')
 
     # Store a list of the currently opened files so we can compare
     # against them when the test is done.
-    if item.config.getvalue('open_files') and not ignore:
-        item.open_files = _get_open_file_list()
+    if item.config.getvalue('open_files'):
+
+        # Retain backwards compatibility with earlier versions of pytest
+        if _pytest_36:
+            ignore = item.get_closest_marker('openfiles_ignore')
+        else:
+            ignore = item.get_marker('openfiles_ignore')
+        if ignore:
+            item.open_files = _get_open_file_list()
 
 
 def pytest_runtest_teardown(item, nextitem):


### PR DESCRIPTION
With `StrictVersion` it will faill to run in pytest-dev itself:

> ValueError: invalid version number '4.3.2.dev44+gaae02863'