### PR TITLE
Switch to matching filenames from open_files_ignore with fnmatch to allow glob-like syntax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.4 (unreleased)
+================
+
+- Added the ability to use ``*`` and ``?`` wildcards in
+  ``open_files_ignore``. [#22]
+
 0.3.2 (2019-01-07)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,11 @@ they reside in the file system::
     open_files_ignore = "output.log"
 
 In this example, all files named ``output.log`` will be ignored if they are
-found to remain open after a test completes.
+found to remain open after a test completes. Paths and filenames can include
+``*`` and ``?`` as wildcards::
+
+    [tool:pytest]
+    open_files_ignore = "*.ttf"
 
 It is also possible to ignore open files for particular test cases by
 decorating them with the ``openfiles_ignore`` decorator:
@@ -88,7 +92,7 @@ Development Status
     :target: https://travis-ci.org/astropy/pytest-openfiles
     :alt: Travis CI Status
 
-.. image:: https://ci.appveyor.com/api/projects/status/944gtt7n0o1d6826/branch/master?svg=true 
+.. image:: https://ci.appveyor.com/api/projects/status/944gtt7n0o1d6826/branch/master?svg=true
     :target: https://ci.appveyor.com/project/Astropy/pytest-openfiles/branch/master
     :alt: Appveyor Status
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ environment:
         platform: x64
 
       - PYTHON_VERSION: "3.5"
+        NUMPY_VERSION: "1.15"
         platform: x64
 
       - PYTHON_VERSION: "3.6"

--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -5,6 +5,7 @@ closed.
 """
 import imp
 import os
+import fnmatch
 
 from distutils.version import StrictVersion
 
@@ -97,14 +98,19 @@ def pytest_runtest_teardown(item, nextitem):
         ignore = False
 
         for ignored in open_files_ignore:
+
+            # Note that we use fnmatch rather than re for simplicity since
+            # we are dealing with file paths. In addition, we used to check
+            # for exact matches, and we need e.g. "astropy.log" to match
+            # only files with that exact name, and not e.g. "astropyxlog"
+            # which would happen if we switched to using regular expression.
+
             if not os.path.isabs(ignored):
-                if os.path.basename(filename) == ignored:
-                    ignore = True
-                    break
-            else:
-                if filename == ignored:
-                    ignore = True
-                    break
+                ignored = os.path.join('*', ignored)
+
+            if fnmatch.filter([filename], ignored):
+                ignore = True
+                break
 
         if ignore:
             continue

--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -100,12 +100,12 @@ def pytest_runtest_teardown(item, nextitem):
         for ignored in open_files_ignore:
 
             # Note that we use fnmatch rather than re for simplicity since
-            # we are dealing with file paths. In addition, we used to check
-            # for exact matches, and we need e.g. "astropy.log" to match
-            # only files with that exact name, and not e.g. "astropyxlog"
-            # which would happen if we switched to using regular expression.
+            # we are dealing with file paths - fnmatch works with the standard
+            # * and ? wildcards in paths.
 
             if not os.path.isabs(ignored):
+                # Since the path is not absolute, we convert it to
+                # */<original_path> to make sure it matches absolute paths.
                 ignored = os.path.join('*', ignored)
 
             if fnmatch.filter([filename], ignored):

--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -108,7 +108,7 @@ def pytest_runtest_teardown(item, nextitem):
                 # */<original_path> to make sure it matches absolute paths.
                 ignored = os.path.join('*', ignored)
 
-            if fnmatch.filter([filename], ignored):
+            if fnmatch.fnmatch(filename, ignored):
                 ignore = True
                 break
 


### PR DESCRIPTION
With this PR, we can now write e.g.:

```
open_files_ignore = "astropy.log" "/etc/hosts" "*.ttf"
```

and ``?`` can also be used. I opted for this over using regular expressions for (a) simplicity and (b) backward-compatibility. Why write ``.*\.ttf`` when you can write ``*.ttf``...