### PR TITLE
Only import imp when neccesary to avoid deprecation warning

### DIFF
--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -3,7 +3,6 @@
 This plugin provides support for testing whether file-like objects are properly
 closed.
 """
-import imp
 import os
 import fnmatch
 
@@ -14,6 +13,7 @@ import pytest
 try:
     import importlib.machinery as importlib_machinery
 except ImportError:
+    import imp
     importlib_machinery = None
 
 _pytest_36 = LooseVersion(pytest.__version__) >= LooseVersion("3.6")


### PR DESCRIPTION
Before this PR I see this deprecation warning:
```
/Users/bsipocz/munka/devel/other/pytest-openfiles/pytest_openfiles/plugin.py:6: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```