### PR TITLE
Fix bug related to pytest teardown

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.5.0 (unreleased)
 ==================
 
-- No changes yet.
+- Don't raise errors for files that are closed in teardown functions. [#28]
 
 0.4.0 (2019-07-20)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,13 @@ decorating them with the ``openfiles_ignore`` decorator:
 The test function will not be skipped, but any files that are left open by the
 test will be ignored by this plugin.
 
+Note that the check for open files happens *after* any teardown function or
+method relevant to a test has been run, so files that are left open by tests
+but which are closed in teardown functions or methods are not caught. While
+there are cases where it can be useful to do this, for example opening a
+file in ``setup_method`` and closing it in ``teardown_method``, we do not
+recommending relying on this behavior excessively.
+
 
 Development Status
 ------------------

--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -78,7 +78,11 @@ def pytest_runtest_setup(item):
             item.open_files = _get_open_file_list()
 
 
-def pytest_runtest_teardown(item, nextitem):
+def pytest_runtest_makereport(item, call):
+
+    if call.when != 'teardown':
+        return
+
     # a "skipped" test will not have been called with
     # pytest_runtest_setup, so therefore won't have an
     # "open_files" member

--- a/tests/test_open_file_detection.py
+++ b/tests/test_open_file_detection.py
@@ -5,21 +5,34 @@ import pytest
 
 PKG_DATA_DIR = os.path.dirname(__file__)
 
-fd = None
+fd1 = None
+fd2 = None
 
 
 def test_open_file_detection():
-    global fd
-    fd = open(os.path.join(PKG_DATA_DIR, 'data/open_file_detection.txt'))
+    # This test is hard-coded in plugin.py as having one dangling open file
+    global fd1
+    fd1 = open(os.path.join(PKG_DATA_DIR, 'data/open_file_detection.txt'))
+
+
+def test_open_file_detection_closed_in_teardown():
+    # The file handle here should be closed in the teardown function so we
+    # don't expect and error
+    global fd2
+    fd2 = open(os.path.join(PKG_DATA_DIR, 'data/open_file_detection.txt'))
+
 
 @pytest.mark.openfiles_ignore
 def test_skip_open_file_detection():
-    global fd
-    fd = open(os.path.join(PKG_DATA_DIR, 'data/open_file_detection.txt'))
+    # This test would normally fail the check for open files but we have
+    # decorated it in a way so as to ignore the open file error.
+    global fd1
+    fd1 = open(os.path.join(PKG_DATA_DIR, 'data/open_file_detection.txt'))
+
 
 def teardown():
-    if fd is not None:
-        fd.close()
+    if fd2 is not None:
+        fd2.close()
 
 
 class TestClass:

--- a/tests/test_open_file_detection.py
+++ b/tests/test_open_file_detection.py
@@ -20,3 +20,16 @@ def test_skip_open_file_detection():
 def teardown():
     if fd is not None:
         fd.close()
+
+
+class TestClass:
+
+    def setup_method(self, method):
+        self.fd = open(os.path.join(PKG_DATA_DIR, 'data/open_file_detection.txt'))
+
+    def teardown_method(self, method):
+        self.fd.close()
+        self.fd = None
+
+    def test_pass(self):
+        self.fd.read(1)


### PR DESCRIPTION
Currently, the following example will cause the plugin to identify an open file after running ``test_pass``:

```python
class TestClass:

    def setup_method(self, method):
        self.fd = open(os.path.join(PKG_DATA_DIR, 'data/open_file_detection.txt'))

    def teardown_method(self, method):
        self.fd.close()
        self.fd = None

    def test_pass(self):
        self.fd.read(1)
```

However, we really should be testing after any teardown method/function has been called. This PR adds a regression test and also includes a fix.

One thing I'm not sure about is that it almost looks, based on the presence of ``teardown`` in the test file, as though it was deliberate that the check for open files didn't take into account teardown functions/methods. However, I think that's incorrect behavior - if files are explicitly closed in teardown functions/methods, I think we should allow that.

So the bottom line is that this PR changes things so that the check for open files is done after any teardown function/method.

