### PR TITLE
Force garbage collection to avoid issues with memory-mapped arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - No changes yet.
 
+- Force garbage collection before checking for open files. [#30]
+
 0.4.0 (2019-07-20)
 ==================
 
@@ -34,7 +36,6 @@
 ================
 
 - Remove test dependency on astropy. [#4]
-
 
 0.1 (2017-10-09)
 ================

--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -4,6 +4,7 @@ This plugin provides support for testing whether file-like objects are properly
 closed.
 """
 import os
+import gc
 import fnmatch
 
 from distutils.version import LooseVersion
@@ -87,6 +88,13 @@ def pytest_runtest_teardown(item, nextitem):
 
     start_open_files = item.open_files
     del item.open_files
+
+    # We now force garbage collection - we need to do this because e.g. in cases
+    # where a memory mapped array was opened in the test and then goes out of
+    # scope at the end of the test, the original file may still be open but
+    # can be properly closed by forcing gc.collect(). This was found to be
+    # needed for astropy.io.fits under certain circumstances.
+    gc.collect()
 
     open_files = _get_open_file_list()
 


### PR DESCRIPTION
This is a revived version of https://github.com/astropy/pytest-openfiles/pull/7 - there are definitely cases where this helps, which I ran into again today, so I think we should include this fix (I don't see any downsides of doing so).