### PR TITLE
TST: Do not use conda for OSX and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
     on_failure: always
     secure: "oeUf6u1ADyoJr3r++BE7VwuP9m5jenAS6eCT5mtCX/MKAw2YVjgflyuyou5eANiytUnYhUQXsGZ2Gc8BQ5C7ZSrp5sxpLT9nXKtSpqMBUxlnNKlm71NLO49W/q7Zc4Ie86tMu9yUsAen4hAZUOENwGoZlKHTlKST3p9DJ3em6IIoIApMsrimTBw2Ysnyj3RrCIFYmdKsyRdpn5V2gwcMoVE813ALJiGmC2vq5ixeTGQu+vKvTP1y1pw0S7KpXos6wH+w1Z4BGMzxS+uhuLktAw435etUWaWa60ivVhHBQ1zQWdq/O4pkYAN8VrO2L0krg2d7mNnkxU/Y/dXWyBiTBGHbvL4p8EAG3IKYaygRMLvdR5xehs3e1J6t/4URGZwTOCzq4c0ew/XVtQIRsduqtnZOMmXJEuF20gFSV7IQvKRPV58X9vXtdh1q6zEizfQNDC3TCvdHn6shOP/X1pEbB021H/fI8+GyZenVa3Wt//oE/CDcR+ECn8RlAFGz6atI07zK/5v3bZVvEaMYv66nLd1mGgOvB9+jYgK+8IznVLnKGzQ2Yt+bnqJpVrkeLl6chdLLPLIP1VlgFmyHAzeRd2Pje+UIOM0K6JqdvER2P389bcWaQdD0dvK6djYpx3rTvjtlUmPcqN5ODiqYPFV7mW1Taur9bcWqrLHX91Qnx9I="
     if: type = cron
-    
+
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -66,7 +66,7 @@ matrix:
 install:
     - if [[ $TRAVIS_OS_NAME == osx || $TRAVIS_OS_NAME == windows ]]; then
         git clone git://github.com/astropy/ci-helpers.git;
-        source ci-helpers/travis/setup_conda.sh;
+        source ci-helpers/travis/setup_python.sh;
       fi
 
 script:


### PR DESCRIPTION
This will hopefully fix chronic Windows failure. Same patch as the one we applied to `astropy`.

Current error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'c:\\tools\\miniconda3\\envs\\test\\Lib\\venv\\scripts\\nt\\python.exe'
```