### PR TITLE
MNT: Replace distutils with packaging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.6.0 (unreleased)
 ==================
 
-- No changes yet.
+- Replaced ``distutils`` with ``packaging``; the latter now a required
+  dependency. [#43]
 
 0.5.0 (2020-04-16)
 ==================

--- a/pytest_openfiles/plugin.py
+++ b/pytest_openfiles/plugin.py
@@ -7,7 +7,7 @@ import os
 import gc
 import fnmatch
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pytest
 
@@ -17,7 +17,7 @@ except ImportError:
     import imp
     importlib_machinery = None
 
-_pytest_36 = LooseVersion(pytest.__version__) >= LooseVersion("3.6")
+_pytest_36 = Version(pytest.__version__) >= Version("3.6")
 
 
 def pytest_addoption(parser):

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ python_requires = >=3.6
 setup_requires =
     setuptools_scm
 install_requires =
+    packaging
     pytest>=4.6
     psutil
 


### PR DESCRIPTION
`distutils` is deprecated.